### PR TITLE
Hooks are stable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,6 @@ function CelsiusThermometer({ state, setState, promap }) {
 Compared to Redux and similar (ngrx, Vuex):
 
 - No actions means no support for Redux DevTools
-- Hooks are still in Alpha, and not yet supported in React Native
 - This library itself is not used in production yet
 
 ## API


### PR DESCRIPTION
Hooks are [stable in 16.8](https://reactjs.org/blog/2019/02/06/react-v16.8.0.html) and [supported in React Native 0.59](https://facebook.github.io/react-native/blog/#hooks-are-here).

Interesting lib, as always, Andre.